### PR TITLE
Improved Author Name & URL XPath for AO3

### DIFF
--- a/ffn_bot/fetchers/ao3.py
+++ b/ffn_bot/fetchers/ao3.py
@@ -18,8 +18,8 @@ AO3_LINK_REGEX = AO3_LINK_REGEX = re.compile(
     re.IGNORECASE)
 AO3_FUNCTION = "linkao3"
 AO3_SEARCH_QUERY = "site:archiveofourown.org/works/ %s"
-AO3_AUTHOR_NAME = '//a[@rel="author"]/text()'
-AO3_AUTHOR_URL = '//a[@rel="author"]/@href'
+AO3_AUTHOR_NAME = '//h3[@class="byline heading"]/a[@rel="author"]/text()
+AO3_AUTHOR_URL = '//h3[@class="byline heading"]/a[@rel="author"]/@href
 AO3_META_PARTS = '//dl[@class="stats"]//text()'
 AO3_TITLE = '//h2/text()'
 AO3_SUMMARY_FINDER = '//*[@id="workskin"]//*[@class="summary module" and @role="complementary"]/blockquote//text()'


### PR DESCRIPTION
Hi, 
Creator of [HPFanfiction Recommender](http://hpffrec.hackesta.org/) here.

I recently noticed some wrong URLs on my website and after investigating I found that the bot is linking incorrect URLs for some AO3 Authors. I looked through your code and found that the XPath you are using can return multiple Authors (and then concatenate them) if the story has been translated. I made the XPath a bit more specific to target the original Author only.

Example: [The Hogwarts Potions Professor](https://archiveofourown.org/works/15475770/chapters/35925678) - linked in the following [comment](https://www.reddit.com/r/HPfanfiction/comments/khbe1x/any_mentor_snape_or_snape_takes_care_of_harry/gglxrjb?utm_source=share&utm_medium=web2x&context=3)