### PR TITLE
fix call to removed collections.sequence

### DIFF
--- a/ffn_bot/metaparse.py
+++ b/ffn_bot/metaparse.py
@@ -45,7 +45,7 @@ def _apply_generator(func, *args, **kwargs):
         for item in result:
             yield item
     elif (
-            (not isinstance(result, collections.Sequence))
+            (not isinstance(result, collections.abc.Sequence))
             or len(result) != 2
             or (isinstance(result, basestring))
     ):

--- a/ffn_bot/site.py
+++ b/ffn_bot/site.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import traceback
 from collections import OrderedDict
 
 from ffn_bot import reddit_markdown
@@ -105,6 +106,7 @@ class Story(object):
         except Exception as e:
             logging.error("(STORY) Could not load story!")
             logging.error(e)
+            traceback.print_exc()
             return ("")
         result = ["\n\n"]
         result.append(


### PR DESCRIPTION
I left in the traceback I used to track this down, it probably won't hurt =)

I'm not 100% sure this will fix it for your instance of the bot, but from what I can tell from my own experience cloning and running  on a private subreddit is that I got back an error that Collections.Sequence didn't exist, found [this](https://stackoverflow.com/questions/69596494/unable-to-import-freegames-python-package-attributeerror-module-collections ) which let me know it was moved in Python 3.10, and I grabbed a traceback find where the error was happening, fixed the call, and then the edited version worked.